### PR TITLE
Camera: Handle duplicate camera Id due to openLegacy support

### DIFF
--- a/services/camera/libcameraservice/common/CameraProviderManager.cpp
+++ b/services/camera/libcameraservice/common/CameraProviderManager.cpp
@@ -631,7 +631,12 @@ status_t CameraProviderManager::ProviderInfo::addDevice(const std::string& name,
 
     mUniqueCameraIds.insert(id);
     if (isAPI1Compatible) {
-        mUniqueAPI1CompatibleCameraIds.push_back(id);
+        // addDevice can be called more than once for the same camera id if HAL
+        // supports openLegacy.
+        if (std::find(mUniqueAPI1CompatibleCameraIds.begin(), mUniqueAPI1CompatibleCameraIds.end(),
+                id) == mUniqueAPI1CompatibleCameraIds.end()) {
+            mUniqueAPI1CompatibleCameraIds.push_back(id);
+        }
     }
 
     if (parsedId != nullptr) {


### PR DESCRIPTION
When HAL supports openLegacy, same camera id can be added more than
once.

Because we now use vector to store API1 compatible camera ids, make
sure no duplicate strings are added.

Test: Vendor camera app using openLegacy, Camera CTS
Bug: 110815837
Bug: 111963599

Change-Id: I327744e102cc75929ebcdf51661f9f4ec7f3acf9
Merged-In: I327744e102cc75929ebcdf51661f9f4ec7f3acf9
(cherry picked from commit 975a39e9067e8d8f71e74813d0199e0e51556bb8)
(cherry picked from commit 258fa2669e4ad01e8de4b12b2084924d30e4bb26)
(cherry picked from commit 2def2f8e943f5968b9e75825100d380080179f89)
Signed-off-by: Pranav Vashi <neobuddy89@gmail.com>